### PR TITLE
Update _mentors.sass

### DIFF
--- a/src/sass/components/_mentors.sass
+++ b/src/sass/components/_mentors.sass
@@ -134,7 +134,7 @@
 
 .mentor__container
 	display: grid
-	width: 700px
+	max-width: 700px
 	grid-gap: 15px
 	grid-template-rows: 150px 150px
 	grid-auto-flow: column


### PR DESCRIPTION
Change container hardcoded width to max-width to avoid issues with last row not being visible on narrower screens

With `width` being set on devices that are smaller than 700 px if you try to scroll mentor section the last row would be cut out

Before, the last point I could scroll to on my phone
![image](https://user-images.githubusercontent.com/1506905/71900760-1ca21c00-3167-11ea-9cb1-3ff999ea12e2.png)
After
![image](https://user-images.githubusercontent.com/1506905/71900780-288dde00-3167-11ea-8ab0-5ff7e72df0d6.png)

 (This was tested in dev preview only)
